### PR TITLE
Add root package.json with concurrently

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,3 +19,14 @@ npm run dev --prefix backend
 npm run build --prefix backend
 npm run start:prod --prefix backend
 ```
+
+### Running the full stack
+
+From the repository root you can install dependencies for both the backend and frontend and start them together:
+
+```bash
+npm run install:all
+npm start
+```
+
+The `start` script uses `concurrently` to run the backend in development mode and the React frontend at the same time.

--- a/package.json
+++ b/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "cyberwar-monorepo",
+  "private": true,
+  "scripts": {
+    "install:all": "npm install --prefix backend && npm install --prefix frontend",
+    "start": "concurrently \"npm run dev --prefix backend\" \"npm start --prefix frontend\""
+  },
+  "devDependencies": {
+    "concurrently": "^9.1.2"
+  }
+}


### PR DESCRIPTION
## Summary
- add a new root `package.json` that runs backend and frontend together
- document how to start both parts using new scripts

## Testing
- `npm install --prefix frontend`
- `CI=true npm test --prefix frontend --silent -- --watchAll=false --passWithNoTests`

------
https://chatgpt.com/codex/tasks/task_e_683f8e8e18588332b723c80fffff7643